### PR TITLE
Chore: Bump Cosmwasm@V3

### DIFF
--- a/packages/neutron-test-tube/Cargo.toml
+++ b/packages/neutron-test-tube/Cargo.toml
@@ -4,7 +4,7 @@ edition     = "2021"
 license     = "MIT OR Apache-2.0"
 name        = "neutron-test-tube"
 repository  = "https://github.com/margined-protocol/test-tube"
-version     = "4.0.1"
+version     = "4.0.1-rc1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 exclude = [ "neutron", "test_artifacts" ]
@@ -18,7 +18,7 @@ margined-neutron-std = { version = "4.0.1" }
 prost                = "0.12.4"
 serde                = "1.0.144"
 serde_json           = "1.0.85"
-test-tube-ntrn       = { version = "0.1.0" }
+test-tube-ntrn       = { version = "0.1.1" }
 thiserror            = "1.0.34"
 
 [build-dependencies]

--- a/packages/neutron-test-tube/Cargo.toml
+++ b/packages/neutron-test-tube/Cargo.toml
@@ -11,10 +11,10 @@ exclude = [ "neutron", "test_artifacts" ]
 
 [dependencies]
 base64               = { version = "0.21.5" }
-cosmrs               = { path = "../../../cosmos-rust/cosmrs" }
-cosmwasm-std         = { version = "3.0.4", features = [ "stargate","cosmwasm_2_0" ] }
+cosmrs = { git = "https://github.com/permissionlessweb/cosmos-rust", branch = "main" }
+cosmwasm-std = { git = "https://github.com/permissionlessweb/cosmwasm", branch = "mvp", features = ["stargate", "cosmwasm_2_0"] }
 hex                  = { version = "0.4.2" }
-neutron-std         = { path = "../../../neutron-std/packages/neutron-std" }
+neutron-std = { git = "https://github.com/permissionlessweb/neutron-std", branch = "feat/cw3" }
 prost                = { version = "0.14.1", features = [ "derive" ] }
 serde                = { version = "1.0.144" }
 serde_json           = { version = "1.0.85" }
@@ -25,5 +25,5 @@ bindgen = "0.60.1"
 
 [dev-dependencies]
 cw1-subkeys        = { version = "3.0.0",git = "https://github.com/permissionlessweb/cw-plus", features = ["library"] }
-cw1-whitelist      = { path = "../../../cw-plus/contracts/cw1-whitelist" }
+cw1-whitelist = { git = "https://github.com/permissionlessweb/cw-plus", branch = "main" }
 rayon         = { version = "1.5.3" }

--- a/packages/neutron-test-tube/Cargo.toml
+++ b/packages/neutron-test-tube/Cargo.toml
@@ -24,6 +24,6 @@ thiserror            = { version = "1.0.34" }
 bindgen = "0.60.1"
 
 [dev-dependencies]
-cw1-subkeys        = { version = "3.0.0",git = "https://github.com/permissionlessweb/cw-plus", branch = "bump/v3", features = ["library"] }
-cw1-whitelist      = { version = "3.0.0", git = "https://github.com/permissionlessweb/cw-plus", branch = "bump/v3" }
+cw1-subkeys        = { version = "3.0.0",git = "https://github.com/permissionlessweb/cw-plus", features = ["library"] }
+cw1-whitelist      = { version = "3.0.0", git = "https://github.com/permissionlessweb/cw-plus" }
 rayon         = { version = "1.5.3" }

--- a/packages/neutron-test-tube/Cargo.toml
+++ b/packages/neutron-test-tube/Cargo.toml
@@ -14,7 +14,7 @@ base64               = { version = "0.21.5" }
 cosmrs               = { version = "0.23.0", features = [ "cosmwasm", "rpc" ], git = "https://github.com/permissionlessweb/cosmos-rust" }
 cosmwasm-std         = { version = "3.0.1", features = [ "stargate","cosmwasm_2_0" ] }
 hex                  = { version = "0.4.2" }
-margined-neutron-std = { version = "5.1.3", path = "../../../abstract/margined-neutron-std" }
+neutron-std         = { version = "6.0.0", git = "https://github.com/permissionlessweb/neutron-std", branch = "feat/cw3" }
 prost                = { version = "0.14.1", features = [ "derive" ] }
 serde                = { version = "1.0.144" }
 serde_json           = { version = "1.0.85" }

--- a/packages/neutron-test-tube/Cargo.toml
+++ b/packages/neutron-test-tube/Cargo.toml
@@ -24,6 +24,6 @@ thiserror            = { version = "1.0.34" }
 bindgen = "0.60.1"
 
 [dev-dependencies]
-cw1-subkeys        = { version = "3.0.0",git = "https://github.com/permissionlessweb/cw-plus", features = ["library"] }
+cw1-subkeys        = { version = "3.0.0",git = "https://github.com/permissionlessweb/cw-plus", branch = "main", features = ["library"] }
 cw1-whitelist = { git = "https://github.com/permissionlessweb/cw-plus", branch = "main" }
 rayon         = { version = "1.5.3" }

--- a/packages/neutron-test-tube/Cargo.toml
+++ b/packages/neutron-test-tube/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [ "neutron", "test_artifacts" ]
 [dependencies]
 base64               = { version = "0.21.5" }
 cosmrs               = { path = "../../../cosmos-rust/cosmrs" }
-cosmwasm-std         = { version = "3.0.1", features = [ "stargate","cosmwasm_2_0" ] }
+cosmwasm-std         = { version = "3.0.4", features = [ "stargate","cosmwasm_2_0" ] }
 hex                  = { version = "0.4.2" }
 neutron-std         = { path = "../../../neutron-std/packages/neutron-std" }
 prost                = { version = "0.14.1", features = [ "derive" ] }

--- a/packages/neutron-test-tube/Cargo.toml
+++ b/packages/neutron-test-tube/Cargo.toml
@@ -11,10 +11,10 @@ exclude = [ "neutron", "test_artifacts" ]
 
 [dependencies]
 base64               = { version = "0.21.5" }
-cosmrs               = { version = "0.23.0", features = [ "cosmwasm", "rpc" ], git = "https://github.com/permissionlessweb/cosmos-rust" }
+cosmrs               = { path = "../../../cosmos-rust/cosmrs" }
 cosmwasm-std         = { version = "3.0.1", features = [ "stargate","cosmwasm_2_0" ] }
 hex                  = { version = "0.4.2" }
-neutron-std         = { version = "6.0.0", git = "https://github.com/permissionlessweb/neutron-std", branch = "feat/cw3" }
+neutron-std         = { path = "../../../neutron-std/packages/neutron-std" }
 prost                = { version = "0.14.1", features = [ "derive" ] }
 serde                = { version = "1.0.144" }
 serde_json           = { version = "1.0.85" }
@@ -25,5 +25,5 @@ bindgen = "0.60.1"
 
 [dev-dependencies]
 cw1-subkeys        = { version = "3.0.0",git = "https://github.com/permissionlessweb/cw-plus", features = ["library"] }
-cw1-whitelist      = { version = "3.0.0", git = "https://github.com/permissionlessweb/cw-plus" }
+cw1-whitelist      = { path = "../../../cw-plus/contracts/cw1-whitelist" }
 rayon         = { version = "1.5.3" }

--- a/packages/neutron-test-tube/Cargo.toml
+++ b/packages/neutron-test-tube/Cargo.toml
@@ -4,27 +4,26 @@ edition     = "2021"
 license     = "MIT OR Apache-2.0"
 name        = "neutron-test-tube"
 repository  = "https://github.com/margined-protocol/test-tube"
-version     = "4.0.1-rc1"
+version     = "5.1.3"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 exclude = [ "neutron", "test_artifacts" ]
 
 [dependencies]
-base64               = "0.21.5"
-cosmrs               = { version = "0.15.0", features = [ "cosmwasm", "rpc" ] }
-cosmwasm-std         = { version = "1.5.4", features = [ "abort", "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "iterator", "stargate" ] }
-hex                  = "0.4.2"
-margined-neutron-std = { version = "4.0.1" }
-prost                = "0.12.4"
-serde                = "1.0.144"
-serde_json           = "1.0.85"
-test-tube-ntrn       = { version = "0.1.1" }
-thiserror            = "1.0.34"
+base64               = { version = "0.21.5" }
+cosmrs               = { version = "0.23.0", features = [ "cosmwasm", "rpc" ], git = "https://github.com/permissionlessweb/cosmos-rust" }
+cosmwasm-std         = { version = "3.0.1", features = [ "stargate","cosmwasm_2_0" ] }
+hex                  = { version = "0.4.2" }
+margined-neutron-std = { version = "5.1.3", path = "../../../abstract/margined-neutron-std" }
+prost                = { version = "0.14.1", features = [ "derive" ] }
+serde                = { version = "1.0.144" }
+serde_json           = { version = "1.0.85" }
+thiserror            = { version = "1.0.34" }
 
 [build-dependencies]
 bindgen = "0.60.1"
 
 [dev-dependencies]
-cw1-subkeys   = "1.1.2"
-cw1-whitelist = "1.1.2"
-rayon         = "1.5.3"
+cw1-subkeys        = { version = "3.0.0",git = "https://github.com/permissionlessweb/cw-plus", branch = "bump/v3", features = ["library"] }
+cw1-whitelist      = { version = "3.0.0", git = "https://github.com/permissionlessweb/cw-plus", branch = "bump/v3" }
+rayon         = { version = "1.5.3" }

--- a/packages/neutron-test-tube/README.md
+++ b/packages/neutron-test-tube/README.md
@@ -248,8 +248,8 @@ Let's try to interact with `Exchange` module:
 
 ```rust
 use cosmwasm_std::Coin;
-use margined_neutron_std::shim::Any;
-use margined_neutron_std::types::{
+use neutron_std::shim::Any;
+use neutron_std::types::{
     cosmos::bank::v1beta1::{MsgSend, QueryBalanceRequest, SendAuthorization},
     cosmos::base::v1beta1::Coin as BaseCoin,
     neutron::dex as DexTypes,

--- a/packages/neutron-test-tube/libntrntesttube/main.go
+++ b/packages/neutron-test-tube/libntrntesttube/main.go
@@ -3,7 +3,6 @@ package main
 import "C"
 
 import (
-	// std
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -67,8 +66,6 @@ func InitTestEnv() uint64 { // Temp fix for concurrency issue
 	env.Ctx = newCtx
 
 	reqFinalizeBlock := abci.RequestFinalizeBlock{Height: env.Ctx.BlockHeight(), Txs: [][]byte{}, Time: newBlockTime}
-
-	// env.Ctx = env.App.NewContext(false)
 
 	env.App.FinalizeBlock(&reqFinalizeBlock)
 	env.App.Commit()
@@ -136,7 +133,6 @@ func IncreaseTime(envId uint64, seconds uint64) {
 //export FinalizeBlock
 func FinalizeBlock(envId uint64, base64ReqDeliverTx string) *C.char {
 	return internalFinalizeBlock(envId, base64ReqDeliverTx, 3)
-
 }
 
 func internalFinalizeBlock(envId uint64, base64ReqDeliverTx string, seconds uint64) *C.char {

--- a/packages/neutron-test-tube/libntrntesttube/testenv/setup.go
+++ b/packages/neutron-test-tube/libntrntesttube/testenv/setup.go
@@ -249,16 +249,6 @@ func (env *TestEnv) BeginNewBlock(executeNextEpoch bool, timeIncreaseSeconds uin
 	env.Ctx = env.App.NewContext(false)
 }
 
-// func (env *TestEnv) GetValidatorAddresses() []string {
-// 	validators := env.App.StakingKeeper.GetAllValidators(env.Ctx)
-// 	var addresses []string
-// 	for _, validator := range validators {
-// 		addresses = append(addresses, validator.OperatorAddress)
-// 	}
-
-// 	return addresses
-// }
-
 func (env *TestEnv) GetValidatorPrivateKey() []byte {
 	return env.Validator
 }

--- a/packages/neutron-test-tube/src/account.rs
+++ b/packages/neutron-test-tube/src/account.rs
@@ -1,0 +1,127 @@
+use cosmrs::{
+    crypto::{secp256k1::SigningKey, PublicKey},
+    AccountId,
+};
+use cosmwasm_std::Coin;
+
+pub trait Account {
+    fn public_key(&self) -> PublicKey;
+    fn address(&self) -> String {
+        self.account_id().to_string()
+    }
+    fn prefix(&self) -> &str;
+    fn account_id(&self) -> AccountId {
+        self.public_key()
+            .account_id(self.prefix())
+            .expect("Prefix is constant and must valid")
+    }
+}
+pub struct SigningAccount {
+    prefix: String,
+    signing_key: SigningKey,
+    fee_setting: FeeSetting,
+}
+
+impl SigningAccount {
+    pub fn new(prefix: String, signing_key: SigningKey, fee_setting: FeeSetting) -> Self {
+        SigningAccount {
+            prefix,
+            signing_key,
+            fee_setting,
+        }
+    }
+
+    pub fn with_prefix(self, prefix: String) -> Self {
+        Self {
+            prefix,
+            signing_key: self.signing_key,
+            fee_setting: self.fee_setting,
+        }
+    }
+
+    pub fn fee_setting(&self) -> &FeeSetting {
+        &self.fee_setting
+    }
+
+    pub fn with_fee_setting(self, fee_setting: FeeSetting) -> Self {
+        Self {
+            prefix: self.prefix,
+            signing_key: self.signing_key,
+            fee_setting,
+        }
+    }
+}
+
+impl Account for SigningAccount {
+    fn public_key(&self) -> PublicKey {
+        self.signing_key.public_key()
+    }
+
+    fn prefix(&self) -> &str {
+        &self.prefix
+    }
+}
+
+impl SigningAccount {
+    pub fn signing_key(&'_ self) -> &'_ SigningKey {
+        &self.signing_key
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonSigningAccount {
+    prefix: String,
+    public_key: PublicKey,
+}
+
+impl From<PublicKey> for NonSigningAccount {
+    fn from(public_key: PublicKey) -> Self {
+        NonSigningAccount {
+            prefix: String::from(""),
+            public_key,
+        }
+    }
+}
+impl From<SigningAccount> for NonSigningAccount {
+    fn from(signing_account: SigningAccount) -> Self {
+        NonSigningAccount {
+            prefix: signing_account.prefix.clone(),
+            public_key: signing_account.public_key(),
+        }
+    }
+}
+
+impl NonSigningAccount {
+    pub fn new(prefix: String, public_key: PublicKey) -> Self {
+        NonSigningAccount { prefix, public_key }
+    }
+
+    pub fn with_prefix(self, prefix: String) -> Self {
+        Self {
+            prefix,
+            public_key: self.public_key,
+        }
+    }
+}
+
+impl Account for NonSigningAccount {
+    fn public_key(&self) -> PublicKey {
+        self.public_key
+    }
+
+    fn prefix(&self) -> &str {
+        &self.prefix
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FeeSetting {
+    Auto {
+        gas_price: Coin,
+        gas_adjustment: f64,
+    },
+    Custom {
+        amount: Coin,
+        gas_limit: u64,
+    },
+}

--- a/packages/neutron-test-tube/src/bindings.rs
+++ b/packages/neutron-test-tube/src/bindings.rs
@@ -1,0 +1,270 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+
+#[derive(PartialEq, Eq, Copy, Clone, Hash, Debug, Default)]
+#[repr(C)]
+pub struct __BindgenComplex<T> {
+    pub re: T,
+    pub im: T,
+}
+pub type size_t = ::std::os::raw::c_ulong;
+pub type wchar_t = ::std::os::raw::c_int;
+pub type max_align_t = f64;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _GoString_ {
+    pub p: *const ::std::os::raw::c_char,
+    pub n: isize,
+}
+#[test]
+fn bindgen_test_layout__GoString_() {
+    assert_eq!(
+        ::std::mem::size_of::<_GoString_>(),
+        16usize,
+        concat!("Size of: ", stringify!(_GoString_))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_GoString_>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_GoString_))
+    );
+    fn test_field_p() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<_GoString_>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).p) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(_GoString_),
+                "::",
+                stringify!(p)
+            )
+        );
+    }
+    test_field_p();
+    fn test_field_n() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<_GoString_>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).n) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(_GoString_),
+                "::",
+                stringify!(n)
+            )
+        );
+    }
+    test_field_n();
+}
+pub type GoInt8 = ::std::os::raw::c_schar;
+pub type GoUint8 = ::std::os::raw::c_uchar;
+pub type GoInt16 = ::std::os::raw::c_short;
+pub type GoUint16 = ::std::os::raw::c_ushort;
+pub type GoInt32 = ::std::os::raw::c_int;
+pub type GoUint32 = ::std::os::raw::c_uint;
+pub type GoInt64 = ::std::os::raw::c_longlong;
+pub type GoUint64 = ::std::os::raw::c_ulonglong;
+pub type GoInt = GoInt64;
+pub type GoUint = GoUint64;
+pub type GoUintptr = size_t;
+pub type GoFloat32 = f32;
+pub type GoFloat64 = f64;
+pub type GoComplex64 = __BindgenComplex<f32>;
+pub type GoComplex128 = __BindgenComplex<f64>;
+pub type _check_for_64_bit_pointer_matching_GoInt = [::std::os::raw::c_char; 1usize];
+pub type GoString = _GoString_;
+pub type GoMap = *mut ::std::os::raw::c_void;
+pub type GoChan = *mut ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct GoInterface {
+    pub t: *mut ::std::os::raw::c_void,
+    pub v: *mut ::std::os::raw::c_void,
+}
+#[test]
+fn bindgen_test_layout_GoInterface() {
+    assert_eq!(
+        ::std::mem::size_of::<GoInterface>(),
+        16usize,
+        concat!("Size of: ", stringify!(GoInterface))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<GoInterface>(),
+        8usize,
+        concat!("Alignment of ", stringify!(GoInterface))
+    );
+    fn test_field_t() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<GoInterface>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).t) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(GoInterface),
+                "::",
+                stringify!(t)
+            )
+        );
+    }
+    test_field_t();
+    fn test_field_v() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<GoInterface>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(GoInterface),
+                "::",
+                stringify!(v)
+            )
+        );
+    }
+    test_field_v();
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct GoSlice {
+    pub data: *mut ::std::os::raw::c_void,
+    pub len: GoInt,
+    pub cap: GoInt,
+}
+#[test]
+fn bindgen_test_layout_GoSlice() {
+    assert_eq!(
+        ::std::mem::size_of::<GoSlice>(),
+        24usize,
+        concat!("Size of: ", stringify!(GoSlice))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<GoSlice>(),
+        8usize,
+        concat!("Alignment of ", stringify!(GoSlice))
+    );
+    fn test_field_data() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<GoSlice>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(GoSlice),
+                "::",
+                stringify!(data)
+            )
+        );
+    }
+    test_field_data();
+    fn test_field_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<GoSlice>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(GoSlice),
+                "::",
+                stringify!(len)
+            )
+        );
+    }
+    test_field_len();
+    fn test_field_cap() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<GoSlice>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cap) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(GoSlice),
+                "::",
+                stringify!(cap)
+            )
+        );
+    }
+    test_field_cap();
+}
+extern "C" {
+    pub fn InitTestEnv() -> GoUint64;
+}
+extern "C" {
+    pub fn InitAccount(envId: GoUint64, coinsJson: GoString) -> *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn FinalizeBlock(envId: GoUint64, tx: GoString) -> *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn IncreaseTime(envId: GoUint64, seconds: GoInt64);
+}
+extern "C" {
+    pub fn SetSlinkyPrices(envId: GoUint64, pricesJson: GoString);
+}
+extern "C" {
+    pub fn Query(
+        envId: GoUint64,
+        path: GoString,
+        base64QueryMsgBytes: GoString,
+    ) -> *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn AccountSequence(envId: GoUint64, bech32Address: GoString) -> GoUint64;
+}
+extern "C" {
+    pub fn AccountNumber(envId: GoUint64, bech32Address: GoString) -> GoUint64;
+}
+extern "C" {
+    pub fn Simulate(envId: GoUint64, base64TxBytes: GoString) -> *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn SetParamSet(
+        envId: GoUint64,
+        subspaceName: GoString,
+        base64ParamSetBytes: GoString,
+    ) -> *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn GetParamSet(
+        envId: GoUint64,
+        subspaceName: GoString,
+        typeUrl: GoString,
+    ) -> *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn GetValidatorAddress(envId: GoUint64, n: GoInt32) -> *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn GetValidatorPrivateKey(envId: GoUint64, n: GoInt32) -> *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn GetBlockTime(envId: GoUint64) -> GoInt64;
+}
+extern "C" {
+    pub fn GetBlockHeight(envId: GoUint64) -> GoInt64;
+}
+extern "C" {
+    pub fn CleanUp(envId: GoUint64);
+}

--- a/packages/neutron-test-tube/src/conversions.rs
+++ b/packages/neutron-test-tube/src/conversions.rs
@@ -1,0 +1,27 @@
+use crate::bindings::GoString;
+use std::ffi::CString;
+
+/// conversion from &CString to GoString
+impl From<&CString> for GoString {
+    fn from(c_str: &CString) -> Self {
+        let ptr_c_str = c_str.as_ptr();
+
+        GoString {
+            p: ptr_c_str,
+            n: c_str.as_bytes().len() as isize,
+        }
+    }
+}
+
+/// This is needed to be implemented as macro since
+/// conversion from &CString to GoString requires
+/// CString to not get dropped before referecing its pointer
+#[macro_export]
+macro_rules! redefine_as_go_string {
+    ($($ident:ident),*) => {
+        $(
+            let $ident = &std::ffi::CString::new($ident).unwrap();
+            let $ident: $crate::bindings::GoString = $ident.into();
+        )*
+    };
+}

--- a/packages/neutron-test-tube/src/lib.rs
+++ b/packages/neutron-test-tube/src/lib.rs
@@ -4,6 +4,7 @@ mod module;
 mod runner;
 
 pub use cosmrs;
+pub use margined_neutron_std;
 
 pub use module::*;
 pub use runner::app::NeutronTestApp;

--- a/packages/neutron-test-tube/src/lib.rs
+++ b/packages/neutron-test-tube/src/lib.rs
@@ -1,15 +1,18 @@
 #![doc = include_str!("../README.md")]
 
+pub mod account;
+pub mod bindings;
+mod conversions;
 mod module;
 mod runner;
+pub mod utils;
 
 pub use cosmrs;
-pub use margined_neutron_std;
+pub use margined_neutron_std as neutron_std;
 
+pub use account::{Account, FeeSetting, NonSigningAccount, SigningAccount};
 pub use module::*;
 pub use runner::app::NeutronTestApp;
-pub use test_tube_ntrn::account::{Account, FeeSetting, NonSigningAccount, SigningAccount};
-pub use test_tube_ntrn::runner::error::{DecodeError, EncodeError, RunnerError};
-pub use test_tube_ntrn::runner::result::{ExecuteResponse, RunnerExecuteResult, RunnerResult};
-pub use test_tube_ntrn::runner::Runner;
-pub use test_tube_ntrn::{fn_execute, fn_query};
+pub use runner::error::{DecodeError, EncodeError, RunnerError};
+pub use runner::result::{ExecuteResponse, RunnerExecuteResult, RunnerResult};
+pub use runner::Runner;

--- a/packages/neutron-test-tube/src/lib.rs
+++ b/packages/neutron-test-tube/src/lib.rs
@@ -8,7 +8,7 @@ mod runner;
 pub mod utils;
 
 pub use cosmrs;
-pub use margined_neutron_std as neutron_std;
+pub use neutron_std as neutron_std;
 
 pub use account::{Account, FeeSetting, NonSigningAccount, SigningAccount};
 pub use module::*;

--- a/packages/neutron-test-tube/src/module/adminmodule.rs
+++ b/packages/neutron-test-tube/src/module/adminmodule.rs
@@ -1,0 +1,39 @@
+use margined_neutron_std::types::cosmos::adminmodule::adminmodule::{
+    MsgAddAdmin, MsgAddAdminResponse, MsgDeleteAdmin, MsgDeleteAdminResponse, MsgSubmitProposal,
+    MsgSubmitProposalResponse, QueryAdminsRequest, QueryAdminsResponse,
+};
+use crate::{fn_execute, fn_query};
+
+use crate::module::Module;
+use crate::runner::Runner;
+
+pub struct Admin<'a, R: Runner<'a>> {
+    runner: &'a R,
+}
+
+impl<'a, R: Runner<'a>> Module<'a, R> for Admin<'a, R> {
+    fn new(runner: &'a R) -> Self {
+        Self { runner }
+    }
+}
+
+impl<'a, R> Admin<'a, R>
+where
+    R: Runner<'a>,
+{
+    fn_execute! {
+        pub add_admin: MsgAddAdmin["/cosmos.adminmodule.adminmodule.MsgAddAdmin"] => MsgAddAdminResponse
+    }
+
+    fn_execute! {
+        pub delete_admin: MsgDeleteAdmin["/cosmos.adminmodule.adminmodule.MsgDeleteAdmin"] => MsgDeleteAdminResponse
+    }
+
+    fn_execute! {
+        pub submit_proposal: MsgSubmitProposal => MsgSubmitProposalResponse
+    }
+
+    fn_query! {
+        pub query_admins ["/cosmos.adminmodule.adminmodule.Query/Admins"]: QueryAdminsRequest => QueryAdminsResponse
+    }
+}

--- a/packages/neutron-test-tube/src/module/adminmodule.rs
+++ b/packages/neutron-test-tube/src/module/adminmodule.rs
@@ -1,4 +1,4 @@
-use margined_neutron_std::types::cosmos::adminmodule::adminmodule::{
+use neutron_std::types::cosmos::adminmodule::adminmodule::{
     MsgAddAdmin, MsgAddAdminResponse, MsgDeleteAdmin, MsgDeleteAdminResponse, MsgSubmitProposal,
     MsgSubmitProposalResponse, QueryAdminsRequest, QueryAdminsResponse,
 };

--- a/packages/neutron-test-tube/src/module/authz.rs
+++ b/packages/neutron-test-tube/src/module/authz.rs
@@ -3,10 +3,11 @@ use margined_neutron_std::types::cosmos::authz::v1beta1::{
     QueryGranteeGrantsResponse, QueryGranterGrantsRequest, QueryGranterGrantsResponse,
     QueryGrantsRequest, QueryGrantsResponse,
 };
-use test_tube_ntrn::{fn_execute, fn_query};
 
-use test_tube_ntrn::module::Module;
-use test_tube_ntrn::runner::Runner;
+use crate::{fn_execute, fn_query};
+
+use crate::module::Module;
+use crate::runner::Runner;
 
 pub struct Authz<'a, R: Runner<'a>> {
     runner: &'a R,
@@ -58,7 +59,7 @@ mod tests {
     use prost::Message;
 
     use crate::{Account, Authz, Bank, NeutronTestApp};
-    use test_tube_ntrn::Module;
+    use crate::Module;
 
     #[test]
     fn authz_integration() {

--- a/packages/neutron-test-tube/src/module/authz.rs
+++ b/packages/neutron-test-tube/src/module/authz.rs
@@ -1,4 +1,4 @@
-use margined_neutron_std::types::cosmos::authz::v1beta1::{
+use neutron_std::types::cosmos::authz::v1beta1::{
     MsgExec, MsgExecResponse, MsgGrant, MsgGrantResponse, QueryGranteeGrantsRequest,
     QueryGranteeGrantsResponse, QueryGranterGrantsRequest, QueryGranterGrantsResponse,
     QueryGrantsRequest, QueryGrantsResponse,
@@ -47,8 +47,8 @@ where
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::Coin;
-    use margined_neutron_std::shim::Any;
-    use margined_neutron_std::types::{
+    use neutron_std::shim::Any;
+    use neutron_std::types::{
         cosmos::authz::v1beta1::{
             GenericAuthorization, Grant, GrantAuthorization, MsgExec, MsgGrant,
             QueryGranteeGrantsRequest, QueryGranterGrantsRequest,

--- a/packages/neutron-test-tube/src/module/bank.rs
+++ b/packages/neutron-test-tube/src/module/bank.rs
@@ -1,5 +1,5 @@
 use crate::{fn_execute, fn_query};
-use margined_neutron_std::types::cosmos::bank::v1beta1::{
+use neutron_std::types::cosmos::bank::v1beta1::{
     MsgSend, MsgSendResponse, QueryAllBalancesRequest, QueryAllBalancesResponse,
     QueryBalanceRequest, QueryBalanceResponse, QueryTotalSupplyRequest, QueryTotalSupplyResponse,
 };
@@ -41,8 +41,8 @@ where
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::Coin;
-    use margined_neutron_std::types::cosmos::bank::v1beta1::{MsgSend, QueryBalanceRequest};
-    use margined_neutron_std::types::cosmos::base::v1beta1::Coin as BaseCoin;
+    use neutron_std::types::cosmos::bank::v1beta1::{MsgSend, QueryBalanceRequest};
+    use neutron_std::types::cosmos::base::v1beta1::Coin as BaseCoin;
 
     use crate::Module;
     use crate::{Account, Bank, NeutronTestApp};

--- a/packages/neutron-test-tube/src/module/bank.rs
+++ b/packages/neutron-test-tube/src/module/bank.rs
@@ -1,11 +1,11 @@
+use crate::{fn_execute, fn_query};
 use margined_neutron_std::types::cosmos::bank::v1beta1::{
     MsgSend, MsgSendResponse, QueryAllBalancesRequest, QueryAllBalancesResponse,
     QueryBalanceRequest, QueryBalanceResponse, QueryTotalSupplyRequest, QueryTotalSupplyResponse,
 };
-use test_tube_ntrn::{fn_execute, fn_query};
 
-use test_tube_ntrn::module::Module;
-use test_tube_ntrn::runner::Runner;
+use crate::module::Module;
+use crate::runner::Runner;
 
 pub struct Bank<'a, R: Runner<'a>> {
     runner: &'a R,
@@ -44,8 +44,8 @@ mod tests {
     use margined_neutron_std::types::cosmos::bank::v1beta1::{MsgSend, QueryBalanceRequest};
     use margined_neutron_std::types::cosmos::base::v1beta1::Coin as BaseCoin;
 
+    use crate::Module;
     use crate::{Account, Bank, NeutronTestApp};
-    use test_tube_ntrn::Module;
 
     #[test]
     fn bank_integration() {

--- a/packages/neutron-test-tube/src/module/dex.rs
+++ b/packages/neutron-test-tube/src/module/dex.rs
@@ -118,15 +118,9 @@ where
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::Coin;
-    use margined_neutron_std::shim::Any;
-    use margined_neutron_std::types::{
-        cosmos::bank::v1beta1::{MsgSend, QueryBalanceRequest, SendAuthorization},
-        cosmos::base::v1beta1::Coin as BaseCoin,
-        neutron::dex as DexTypes,
-    };
-    use prost::Message;
+    use margined_neutron_std::types::neutron::dex as DexTypes;
 
-    use crate::{Account, Bank, Dex, NeutronTestApp};
+    use crate::{Account, Dex, NeutronTestApp};
     use test_tube_ntrn::Module;
 
     #[test]
@@ -138,38 +132,32 @@ mod tests {
                 Coin::new(1_000_000_000_000u128, "usdc"),
             ])
             .unwrap();
-        let receiver = app
-            .init_account(&[Coin::new(1_000_000_000_000u128, "untrn")])
-            .unwrap();
         let dex = Dex::new(&app);
-        let bank = Bank::new(&app);
 
         let scale_factor = 1_000_000_000_000_000_000u128;
 
-        let res = dex
-            .place_limit_order(
-                DexTypes::MsgPlaceLimitOrder {
-                    creator: signer.address().clone(),
-                    receiver: signer.address().clone(),
-                    token_in: "untrn".to_string(),
-                    token_out: "usdc".to_string(),
-                    tick_index_in_to_out: 0,
-                    amount_in: (10_000_000_000_000_000_00u128).to_string(),
-                    order_type: 0,
-                    expiration_time: None,
-                    max_amount_out: "".to_string(),
-                    limit_sell_price: (10u128 * scale_factor).to_string(),
-                },
-                &signer,
-            )
-            .unwrap();
-
-        let res = dex
-            .tick_liquidity_all(&DexTypes::QueryAllTickLiquidityRequest {
-                pair_id: "untrn<>usdc".to_string(),
+        dex.place_limit_order(
+            DexTypes::MsgPlaceLimitOrder {
+                creator: signer.address().clone(),
+                receiver: signer.address().clone(),
                 token_in: "untrn".to_string(),
-                pagination: None,
-            })
-            .unwrap();
+                token_out: "usdc".to_string(),
+                tick_index_in_to_out: 0,
+                amount_in: 1_000_000_000_000_000_000u128.to_string(),
+                order_type: 0,
+                expiration_time: None,
+                max_amount_out: "".to_string(),
+                limit_sell_price: (10u128 * scale_factor).to_string(),
+            },
+            &signer,
+        )
+        .unwrap();
+
+        dex.tick_liquidity_all(&DexTypes::QueryAllTickLiquidityRequest {
+            pair_id: "untrn<>usdc".to_string(),
+            token_in: "untrn".to_string(),
+            pagination: None,
+        })
+        .unwrap();
     }
 }

--- a/packages/neutron-test-tube/src/module/dex.rs
+++ b/packages/neutron-test-tube/src/module/dex.rs
@@ -1,5 +1,5 @@
 use crate::{fn_execute, fn_query};
-use margined_neutron_std::types::neutron::dex as DexTypes;
+use neutron_std::types::neutron::dex as DexTypes;
 
 use crate::module::Module;
 use crate::runner::Runner;
@@ -118,7 +118,7 @@ where
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::Coin;
-    use margined_neutron_std::types::neutron::dex as DexTypes;
+    use neutron_std::types::neutron::dex as DexTypes;
 
     use crate::Module;
     use crate::{Account, Dex, NeutronTestApp};
@@ -146,9 +146,9 @@ mod tests {
                 amount_in: 1_000_000_000_000_000_000u128.to_string(),
                 order_type: 0,
                 expiration_time: None,
-                max_amount_out: "".to_string(),
-                limit_sell_price: (10u128 * scale_factor).to_string(),
-                min_average_sell_price: "".to_string(),
+                max_amount_out: Some("".to_string()),
+                limit_sell_price: Some((10u128 * scale_factor).to_string()),
+                min_average_sell_price: Some("".to_string()),
             },
             &signer,
         )

--- a/packages/neutron-test-tube/src/module/dex.rs
+++ b/packages/neutron-test-tube/src/module/dex.rs
@@ -1,8 +1,8 @@
+use crate::{fn_execute, fn_query};
 use margined_neutron_std::types::neutron::dex as DexTypes;
-use test_tube_ntrn::{fn_execute, fn_query};
 
-use test_tube_ntrn::module::Module;
-use test_tube_ntrn::runner::Runner;
+use crate::module::Module;
+use crate::runner::Runner;
 
 pub struct Dex<'a, R: Runner<'a>> {
     runner: &'a R,
@@ -120,8 +120,8 @@ mod tests {
     use cosmwasm_std::Coin;
     use margined_neutron_std::types::neutron::dex as DexTypes;
 
+    use crate::Module;
     use crate::{Account, Dex, NeutronTestApp};
-    use test_tube_ntrn::Module;
 
     #[test]
     fn dex_integration() {
@@ -148,6 +148,7 @@ mod tests {
                 expiration_time: None,
                 max_amount_out: "".to_string(),
                 limit_sell_price: (10u128 * scale_factor).to_string(),
+                min_average_sell_price: "".to_string(),
             },
             &signer,
         )

--- a/packages/neutron-test-tube/src/module/gov.rs
+++ b/packages/neutron-test-tube/src/module/gov.rs
@@ -1,11 +1,24 @@
-use margined_neutron_std::types::cosmos::gov::v1::{
-    MsgSubmitProposal, MsgSubmitProposalResponse, MsgVote, MsgVoteResponse, QueryProposalRequest,
-    QueryProposalResponse,
+use cosmrs::tx::MessageExt;
+use margined_neutron_std::shim::Any;
+use margined_neutron_std::types::cosmos::{
+    adminmodule::adminmodule::MsgSubmitProposal,
+    gov::{
+        v1::{
+            MsgSubmitProposalResponse, MsgVote, MsgVoteResponse, QueryParamsRequest,
+            QueryParamsResponse, QueryProposalRequest, QueryProposalResponse,
+            QueryProposalsRequest, QueryProposalsResponse, VoteOption,
+        },
+        v1beta1,
+    },
 };
-use margined_neutron_std::types::cosmos::gov::v1beta1;
-use test_tube_ntrn::module::Module;
-use test_tube_ntrn::runner::Runner;
-use test_tube_ntrn::{fn_execute, fn_query};
+use crate::module::Module;
+use crate::runner::Runner;
+use crate::{
+    fn_execute, fn_query, Account, RunnerError, RunnerExecuteResult, SigningAccount,
+};
+
+use crate::NeutronTestApp;
+
 
 pub struct Gov<'a, R: Runner<'a>> {
     runner: &'a R,
@@ -36,5 +49,72 @@ where
 
     fn_query! {
         pub query_proposal ["/cosmos.gov.v1beta1.Query/Proposal"]: QueryProposalRequest => QueryProposalResponse
+    }
+}
+
+
+/// Extension for Gov module
+/// It has ability to access to `NeutronTestApp` which is more specific than `Runner`
+pub struct GovWithAppAccess<'a> {
+    gov: Gov<'a, NeutronTestApp>,
+    app: &'a NeutronTestApp,
+}
+
+impl<'a> GovWithAppAccess<'a> {
+    pub fn new(app: &'a NeutronTestApp) -> Self {
+        Self {
+            gov: Gov::new(app),
+            app,
+        }
+    }
+
+    pub fn to_gov(&self) -> &Gov<'a, NeutronTestApp> {
+        &self.gov
+    }
+
+    pub fn propose_and_execute<M: prost::Message>(
+        &self,
+        msg_type_url: String,
+        msg: M,
+        proposer: String,
+        signer: &SigningAccount,
+    ) -> RunnerExecuteResult<MsgSubmitProposalResponse> {
+        // submit proposal
+        let submit_proposal_res = self.gov.submit_proposal(
+            MsgSubmitProposal {
+                messages: vec![Any {
+                    type_url: msg_type_url,
+                    value: msg
+                        .to_bytes()
+                        .map_err(|e| RunnerError::EncodeError(e.into()))?,
+                }],
+                proposer,
+            },
+            signer,
+        )?;
+
+        let proposal_id = submit_proposal_res.data.proposal_id;
+
+        // get validator to vote yes for proposal
+        let val = self
+            .app
+            .get_first_validator_signing_account("untrn".to_string(), 1.3)?;
+
+        self.gov
+            .vote(
+                MsgVote {
+                    proposal_id,
+                    voter: val.address(),
+                    option: VoteOption::Yes.into(),
+                    metadata: "".to_string(),
+                },
+                &val,
+            )
+            .unwrap();
+
+        // increase time to pass voting period
+        // self.app.increase_time(voting_period.seconds as u64 + 1);
+
+        Ok(submit_proposal_res)
     }
 }

--- a/packages/neutron-test-tube/src/module/gov.rs
+++ b/packages/neutron-test-tube/src/module/gov.rs
@@ -1,6 +1,6 @@
 use cosmrs::tx::MessageExt;
-use margined_neutron_std::shim::Any;
-use margined_neutron_std::types::cosmos::{
+use neutron_std::shim::Any;
+use neutron_std::types::cosmos::{
     adminmodule::adminmodule::MsgSubmitProposal,
     gov::{
         v1::{

--- a/packages/neutron-test-tube/src/module/macros.rs
+++ b/packages/neutron-test-tube/src/module/macros.rs
@@ -1,0 +1,53 @@
+#[macro_export]
+macro_rules! fn_execute {
+    (pub $name:ident: $req:ty[$type_url:expr] => $res:ty) => {
+        pub fn $name(
+            &self,
+            msg: $req,
+            signer: &$crate::SigningAccount,
+        ) -> $crate::RunnerExecuteResult<$res> {
+            self.runner.execute(msg, $type_url, signer)
+        }
+    };
+    (pub $name:ident: $req:ty => $res:ty) => {
+        pub fn $name(
+            &self,
+            msg: $req,
+            signer: &$crate::SigningAccount,
+        ) -> $crate::RunnerExecuteResult<$res> {
+            self.runner.execute(msg, <$req>::TYPE_URL, signer)
+        }
+    };
+    ($name:ident: $req:ty[$type_url:expr] => $res:ty) => {
+        pub fn $name(
+            &self,
+            msg: $req,
+            signer: &$crate::SigningAccount,
+        ) -> $crate::RunnerExecuteResult<$res> {
+            self.runner.execute(msg, $type_url, signer)
+        }
+    };
+    ($name:ident: $req:ty => $res:ty) => {
+        pub fn $name(
+            &self,
+            msg: $req,
+            signer: &$crate::SigningAccount,
+        ) -> $crate::RunnerExecuteResult<$res> {
+            self.runner.execute(msg, <$req>::TYPE_URL, signer)
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! fn_query {
+    (pub $name:ident [$path:expr]: $req:ty => $res:ty) => {
+        pub fn $name(&self, msg: &$req) -> $crate::RunnerResult<$res> {
+            self.runner.query::<$req, $res>($path, msg)
+        }
+    };
+    ($name:ident [$path:expr]: $req:ty => $res:ty) => {
+        fn $name(&self, msg: &$req) -> $crate::RunnerResult<$res> {
+            self.runner.query::<$req, $res>($path, msg)
+        }
+    };
+}

--- a/packages/neutron-test-tube/src/module/mod.rs
+++ b/packages/neutron-test-tube/src/module/mod.rs
@@ -1,16 +1,27 @@
+mod adminmodule;
 mod authz;
 mod bank;
 mod dex;
 mod gov;
+mod slinky;
 mod tokenfactory;
 mod wasm;
 
-pub use test_tube_ntrn::macros;
-pub use test_tube_ntrn::module::Module;
+#[macro_use]
+pub mod macros;
 
+pub trait Module<'a, R: Runner<'a>> {
+    fn new(runner: &'a R) -> Self;
+}
+
+pub use adminmodule::Admin;
 pub use authz::Authz;
 pub use bank::Bank;
 pub use dex::Dex;
 pub use gov::Gov;
+pub use gov::GovWithAppAccess;
+pub use slinky::Slinky;
 pub use tokenfactory::TokenFactory;
 pub use wasm::Wasm;
+
+use crate::Runner;

--- a/packages/neutron-test-tube/src/module/slinky.rs
+++ b/packages/neutron-test-tube/src/module/slinky.rs
@@ -1,4 +1,4 @@
-use margined_neutron_std::types::slinky::{
+use neutron_std::types::slinky::{
     marketmap::v1 as MarketMapTypesV1, oracle::v1 as OracleTypesV1,
 };
 use crate::{fn_execute, fn_query};
@@ -47,7 +47,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use margined_neutron_std::{
+    use neutron_std::{
         shim::Timestamp,
         types::slinky::{
             marketmap::v1::{Market, MsgCreateMarkets, ProviderConfig, Ticker},

--- a/packages/neutron-test-tube/src/module/slinky.rs
+++ b/packages/neutron-test-tube/src/module/slinky.rs
@@ -1,0 +1,277 @@
+use margined_neutron_std::types::slinky::{
+    marketmap::v1 as MarketMapTypesV1, oracle::v1 as OracleTypesV1,
+};
+use crate::{fn_execute, fn_query};
+
+use crate::module::Module;
+use crate::runner::Runner;
+
+pub struct Slinky<'a, R: Runner<'a>> {
+    runner: &'a R,
+}
+
+impl<'a, R: Runner<'a>> Module<'a, R> for Slinky<'a, R> {
+    fn new(runner: &'a R) -> Self {
+        Self { runner }
+    }
+}
+
+impl<'a, R> Slinky<'a, R>
+where
+    R: Runner<'a>,
+{
+    fn_execute! {
+        pub create_markets: MarketMapTypesV1::MsgCreateMarkets["/slinky.marketmap.v1.MsgCreateMarkets"] => MarketMapTypesV1::MsgCreateMarketsResponse
+    }
+
+    fn_query! {
+        pub get_all_currency_pairs ["/slinky.oracle.v1.Query/GetAllCurrencyPairs"]: OracleTypesV1::GetAllCurrencyPairsRequest => OracleTypesV1::GetAllCurrencyPairsResponse
+    }
+
+    fn_query! {
+        pub get_price ["/slinky.oracle.v1.Query/GetPrice"]: OracleTypesV1::GetPriceRequest => OracleTypesV1::GetPriceResponse
+    }
+
+    fn_query! {
+        pub get_prices ["/slinky.oracle.v1.Query/GetPrices"]: OracleTypesV1::GetPricesRequest => OracleTypesV1::GetPricesResponse
+    }
+
+    fn_query! {
+        pub get_currency_pair_mapping ["/slinky.oracle.v1.Query/GetCurrencyPairMapping"]: OracleTypesV1::GetCurrencyPairMappingRequest => OracleTypesV1::GetCurrencyPairMappingResponse
+    }
+
+    fn_query! {
+        pub get_params ["/slinky.marketmap.v1.Query/Params"]: MarketMapTypesV1::ParamsRequest => MarketMapTypesV1::ParamsResponse
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use margined_neutron_std::{
+        shim::Timestamp,
+        types::slinky::{
+            marketmap::v1::{Market, MsgCreateMarkets, ProviderConfig, Ticker},
+            oracle::v1::{self as OracleTypes, GetPriceResponse, QuotePrice},
+            types::v1::CurrencyPair,
+        },
+    };
+
+    use crate::{Account, NeutronTestApp, Slinky};
+    use crate::{runner::app::SlinkyPrices, Module};
+
+    #[test]
+    fn slinky_integration() {
+        let app = NeutronTestApp::new();
+
+        let slinky = Slinky::new(&app);
+
+        let val = app
+            .get_first_validator_signing_account("untrn".to_string(), 1.3)
+            .unwrap();
+
+        let res = slinky
+            .get_all_currency_pairs(&OracleTypes::GetAllCurrencyPairsRequest {})
+            .unwrap();
+        assert_eq!(
+            res.currency_pairs,
+            vec![CurrencyPair {
+                base: "ATOM".to_string(),
+                quote: "USDT".to_string(),
+            }]
+        );
+
+        slinky
+            .create_markets(
+                MsgCreateMarkets {
+                    authority: val.address(),
+                    create_markets: vec![Market {
+                        ticker: Some(Ticker {
+                            currency_pair: Some(CurrencyPair {
+                                base: "NTRN".to_string(),
+                                quote: "USDC".to_string(),
+                            }),
+                            decimals: 6,
+                            min_provider_count: 1,
+                            enabled: true,
+                            metadata_json: "".to_string(),
+                        }),
+                        provider_configs: vec![ProviderConfig {
+                            name: "margined".to_string(),
+                            off_chain_ticker: "NRTN/USD".to_string(),
+                            normalize_by_pair: None,
+                            invert: false,
+                            metadata_json: "".to_string(),
+                        }],
+                    }],
+                },
+                &val,
+            )
+            .unwrap();
+
+        let res = slinky
+            .get_all_currency_pairs(&OracleTypes::GetAllCurrencyPairsRequest {})
+            .unwrap();
+        assert_eq!(
+            res.currency_pairs,
+            vec![
+                CurrencyPair {
+                    base: "ATOM".to_string(),
+                    quote: "USDT".to_string(),
+                },
+                CurrencyPair {
+                    base: "NTRN".to_string(),
+                    quote: "USDC".to_string(),
+                }
+            ]
+        );
+
+        let res = slinky
+            .get_price(&OracleTypes::GetPriceRequest {
+                currency_pair: Some(CurrencyPair {
+                    base: "ATOM".to_string(),
+                    quote: "USDT".to_string(),
+                }),
+            })
+            .unwrap();
+        assert_eq!(
+            res,
+            GetPriceResponse {
+                price: Some(QuotePrice {
+                    price: "4480000".to_string(),
+                    block_timestamp: Some(Timestamp {
+                        // this is set in genesis so no clue why it is negative
+                        // but lets not worry too much
+                        seconds: -62135596800,
+                        nanos: 0
+                    }),
+                    block_height: 0
+                }),
+                decimals: 8,
+                nonce: 0,
+                id: 0,
+            }
+        );
+
+        let res = slinky
+            .get_price(&OracleTypes::GetPriceRequest {
+                currency_pair: Some(CurrencyPair {
+                    base: "NTRN".to_string(),
+                    quote: "USDC".to_string(),
+                }),
+            })
+            .unwrap();
+        assert_eq!(
+            res,
+            GetPriceResponse {
+                price: Some(QuotePrice {
+                    price: "0".to_string(),
+                    block_timestamp: Some(Timestamp {
+                        // this is set in genesis so no clue why it is negative
+                        // but lets not worry too much
+                        seconds: -62135596800,
+                        nanos: 0
+                    }),
+                    block_height: 0
+                }),
+                decimals: 6,
+                nonce: 0,
+                id: 1,
+            }
+        );
+
+        app.set_slinky_prices(&[SlinkyPrices {
+            base: "ATOM".to_string(),
+            quote: "USDT".to_string(),
+            price: 513000000u128,
+        }]);
+
+        let res = slinky
+            .get_price(&OracleTypes::GetPriceRequest {
+                currency_pair: Some(CurrencyPair {
+                    base: "ATOM".to_string(),
+                    quote: "USDT".to_string(),
+                }),
+            })
+            .unwrap();
+        assert_eq!(res.price.unwrap().price, "513000000".to_string());
+
+        // Set NTRN/USDC
+        app.set_slinky_prices(&[SlinkyPrices {
+            base: "NTRN".to_string(),
+            quote: "USDC".to_string(),
+            price: 4230000u128,
+        }]);
+
+        let res = slinky
+            .get_price(&OracleTypes::GetPriceRequest {
+                currency_pair: Some(CurrencyPair {
+                    base: "NTRN".to_string(),
+                    quote: "USDC".to_string(),
+                }),
+            })
+            .unwrap();
+        assert_eq!(res.price.unwrap().price, "4230000".to_string());
+
+        // Reduce price
+        app.set_slinky_prices(&[SlinkyPrices {
+            base: "NTRN".to_string(),
+            quote: "USDC".to_string(),
+            price: 4130000u128,
+        }]);
+
+        let res = slinky
+            .get_price(&OracleTypes::GetPriceRequest {
+                currency_pair: Some(CurrencyPair {
+                    base: "NTRN".to_string(),
+                    quote: "USDC".to_string(),
+                }),
+            })
+            .unwrap();
+        assert_eq!(res.price.unwrap().price, "4130000".to_string());
+
+        // Reduce price
+        app.set_slinky_prices(&[SlinkyPrices {
+            base: "NTRN".to_string(),
+            quote: "USDC".to_string(),
+            price: 5012345u128,
+        }]);
+        let timestamp = app.get_block_timestamp();
+
+        let res = slinky
+            .get_price(&OracleTypes::GetPriceRequest {
+                currency_pair: Some(CurrencyPair {
+                    base: "NTRN".to_string(),
+                    quote: "USDC".to_string(),
+                }),
+            })
+            .unwrap();
+
+        let price = res.price.unwrap();
+        assert_eq!(price.price, "5012345".to_string());
+        assert_eq!(
+            price.block_timestamp.unwrap().seconds,
+            timestamp.seconds() as i64
+        );
+        assert_eq!(price.block_height, 6);
+
+        app.increase_time(10);
+
+        // see what happens in
+        let res = slinky
+            .get_price(&OracleTypes::GetPriceRequest {
+                currency_pair: Some(CurrencyPair {
+                    base: "NTRN".to_string(),
+                    quote: "USDC".to_string(),
+                }),
+            })
+            .unwrap();
+
+        let price = res.price.unwrap();
+        assert_eq!(price.price, "5012345".to_string());
+        assert_eq!(
+            price.block_timestamp.unwrap().seconds,
+            timestamp.seconds() as i64
+        );
+        assert_eq!(price.block_height, 6);
+    }
+}

--- a/packages/neutron-test-tube/src/module/tokenfactory.rs
+++ b/packages/neutron-test-tube/src/module/tokenfactory.rs
@@ -1,4 +1,4 @@
-use margined_neutron_std::types::osmosis::tokenfactory::v1beta1::{
+use neutron_std::types::osmosis::tokenfactory::v1beta1::{
     MsgBurn, MsgBurnResponse, MsgChangeAdmin, MsgChangeAdminResponse, MsgCreateDenom,
     MsgCreateDenomResponse, MsgMint, MsgMintResponse, MsgSetDenomMetadata,
     MsgSetDenomMetadataResponse, QueryDenomAuthorityMetadataRequest,
@@ -60,8 +60,8 @@ where
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::{Coin, Uint256};
-    use margined_neutron_std::types::cosmos::bank::v1beta1::QueryBalanceRequest;
-    use margined_neutron_std::types::osmosis::tokenfactory::v1beta1::{
+    use neutron_std::types::cosmos::bank::v1beta1::QueryBalanceRequest;
+    use neutron_std::types::osmosis::tokenfactory::v1beta1::{
         MsgBurn, MsgCreateDenom, MsgMint, QueryDenomsFromCreatorRequest,
     };
 
@@ -106,7 +106,7 @@ mod tests {
         assert_eq!(denoms, [denom.clone()]);
 
         // TODO mint new denom
-        let coin: margined_neutron_std::types::cosmos::base::v1beta1::Coin =
+        let coin: neutron_std::types::cosmos::base::v1beta1::Coin =
             Coin::new(Uint256::new(1000000000u128), denom.clone()).into();
         tokenfactory
             .mint(

--- a/packages/neutron-test-tube/src/module/tokenfactory.rs
+++ b/packages/neutron-test-tube/src/module/tokenfactory.rs
@@ -6,9 +6,9 @@ use margined_neutron_std::types::osmosis::tokenfactory::v1beta1::{
     QueryDenomsFromCreatorResponse, QueryParamsRequest, QueryParamsResponse,
 };
 
-use test_tube_ntrn::module::Module;
-use test_tube_ntrn::runner::Runner;
-use test_tube_ntrn::{fn_execute, fn_query};
+use crate::module::Module;
+use crate::runner::Runner;
+use crate::{fn_execute, fn_query};
 
 pub struct TokenFactory<'a, R: Runner<'a>> {
     runner: &'a R,
@@ -59,14 +59,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::Coin;
+    use cosmwasm_std::{Coin, Uint256};
     use margined_neutron_std::types::cosmos::bank::v1beta1::QueryBalanceRequest;
     use margined_neutron_std::types::osmosis::tokenfactory::v1beta1::{
         MsgBurn, MsgCreateDenom, MsgMint, QueryDenomsFromCreatorRequest,
     };
 
+    use crate::Module;
     use crate::{Account, Bank, NeutronTestApp, TokenFactory};
-    use test_tube_ntrn::Module;
 
     #[test]
     fn tokenfactory_integration() {
@@ -107,7 +107,7 @@ mod tests {
 
         // TODO mint new denom
         let coin: margined_neutron_std::types::cosmos::base::v1beta1::Coin =
-            Coin::new(1000000000, denom.clone()).into();
+            Coin::new(Uint256::new(1000000000u128), denom.clone()).into();
         tokenfactory
             .mint(
                 MsgMint {

--- a/packages/neutron-test-tube/src/module/wasm.rs
+++ b/packages/neutron-test-tube/src/module/wasm.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::Coin;
-use margined_neutron_std::types::{
+use neutron_std::types::{
     cosmos::base::v1beta1::Coin as BaseCoin,
     cosmwasm::wasm::v1::{
         AccessConfig, MsgExecuteContract, MsgExecuteContractResponse, MsgInstantiateContract,

--- a/packages/neutron-test-tube/src/module/wasm.rs
+++ b/packages/neutron-test-tube/src/module/wasm.rs
@@ -1,14 +1,18 @@
-use cosmrs::proto::cosmwasm::wasm::v1::{
-    AccessConfig, MsgExecuteContract, MsgExecuteContractResponse, MsgInstantiateContract,
-    MsgInstantiateContractResponse, MsgMigrateContract, MsgMigrateContractResponse, MsgStoreCode,
-    MsgStoreCodeResponse, QuerySmartContractStateRequest, QuerySmartContractStateResponse,
-};
 use cosmwasm_std::Coin;
+use margined_neutron_std::types::{
+    cosmos::base::v1beta1::Coin as BaseCoin,
+    cosmwasm::wasm::v1::{
+        AccessConfig, MsgExecuteContract, MsgExecuteContractResponse, MsgInstantiateContract,
+        MsgInstantiateContractResponse, MsgMigrateContract, MsgMigrateContractResponse,
+        MsgStoreCode, MsgStoreCodeResponse, QuerySmartContractStateRequest,
+        QuerySmartContractStateResponse,
+    },
+};
 use serde::{de::DeserializeOwned, Serialize};
 
-use test_tube_ntrn::runner::error::{DecodeError, EncodeError, RunnerError};
-use test_tube_ntrn::runner::result::{RunnerExecuteResult, RunnerResult};
-use test_tube_ntrn::{
+use crate::runner::error::{DecodeError, EncodeError, RunnerError};
+use crate::runner::result::{RunnerExecuteResult, RunnerResult};
+use crate::{
     account::{Account, SigningAccount},
     runner::Runner,
 };
@@ -65,9 +69,9 @@ where
                 msg: serde_json::to_vec(msg).map_err(EncodeError::JsonEncodeError)?,
                 funds: funds
                     .iter()
-                    .map(|c| cosmrs::proto::cosmos::base::v1beta1::Coin {
+                    .map(|c| BaseCoin {
                         denom: c.denom.parse().unwrap(),
-                        amount: format!("{}", c.amount.u128()),
+                        amount: format!("{}", c.amount.to_string()),
                     })
                     .collect(),
             },
@@ -92,9 +96,9 @@ where
                 msg: serde_json::to_vec(msg).map_err(EncodeError::JsonEncodeError)?,
                 funds: funds
                     .iter()
-                    .map(|c| cosmrs::proto::cosmos::base::v1beta1::Coin {
+                    .map(|c| BaseCoin {
                         denom: c.denom.parse().unwrap(),
-                        amount: format!("{}", c.amount.u128()),
+                        amount: format!("{}", c.amount.to_string()),
                     })
                     .collect(),
                 contract: contract.to_owned(),

--- a/packages/neutron-test-tube/src/runner/app.rs
+++ b/packages/neutron-test-tube/src/runner/app.rs
@@ -149,18 +149,14 @@ impl<'a> Runner<'a> for NeutronTestApp {
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::{coins, Coin};
-    use margined_neutron_std::types::{
-        cosmos::bank::v1beta1::QueryAllBalancesRequest,
-        osmosis::tokenfactory::v1beta1::{
-            MsgCreateDenom, MsgCreateDenomResponse, QueryDenomsFromCreatorRequest,
-            QueryParamsRequest, QueryParamsResponse,
-        },
+    use margined_neutron_std::types::osmosis::tokenfactory::v1beta1::{
+        MsgCreateDenom, MsgCreateDenomResponse, QueryParamsRequest, QueryParamsResponse,
     };
 
-    use crate::module::{Bank, TokenFactory, Wasm};
+    use crate::module::Wasm;
     use crate::runner::app::NeutronTestApp;
 
-    use test_tube_ntrn::account::{Account, FeeSetting};
+    use test_tube_ntrn::account::Account;
     use test_tube_ntrn::module::Module;
     use test_tube_ntrn::runner::*;
     use test_tube_ntrn::ExecuteResponse;

--- a/packages/neutron-test-tube/src/runner/app.rs
+++ b/packages/neutron-test-tube/src/runner/app.rs
@@ -611,7 +611,7 @@ impl<'a> Runner<'a> for NeutronTestApp {
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::{coins, Coin};
-    use margined_neutron_std::types::osmosis::tokenfactory::v1beta1::{
+    use neutron_std::types::osmosis::tokenfactory::v1beta1::{
         MsgCreateDenom, MsgCreateDenomResponse, QueryParamsRequest, QueryParamsResponse,
     };
 

--- a/packages/neutron-test-tube/src/runner/app.rs
+++ b/packages/neutron-test-tube/src/runner/app.rs
@@ -1,16 +1,469 @@
-use cosmwasm_std::Coin;
+use std::ffi::CString;
+use std::fmt::Debug;
 
+use crate::account::{FeeSetting, SigningAccount};
+use crate::bindings::{
+    AccountNumber, AccountSequence, FinalizeBlock, GetBlockHeight, GetBlockTime, GetParamSet,
+    GetValidatorAddress, GetValidatorPrivateKey, IncreaseTime, InitAccount, InitTestEnv, Query,
+    SetParamSet, SetSlinkyPrices, Simulate,
+};
+use crate::runner::error::{DecodeError, EncodeError, RunnerError};
+use crate::runner::result::RawResult;
+use crate::runner::result::{RunnerExecuteResult, RunnerResult};
+use crate::runner::Runner;
+use crate::{redefine_as_go_string, Account};
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine as _;
+use cosmrs::crypto::secp256k1::SigningKey;
+use cosmrs::proto::tendermint::v0_38::abci::ResponseFinalizeBlock;
+use cosmrs::tx;
+use cosmrs::tx::{Fee, SignerInfo};
+use cosmrs::Any;
+use cosmwasm_std::{Coin, Timestamp};
 use prost::Message;
-use test_tube_ntrn::account::SigningAccount;
-
-use test_tube_ntrn::runner::result::{RunnerExecuteResult, RunnerResult};
-use test_tube_ntrn::runner::Runner;
-use test_tube_ntrn::BaseApp;
+use serde::Serialize;
 
 const FEE_DENOM: &str = "untrn";
 const NEUTRON_ADDRESS_PREFIX: &str = "neutron";
 const CHAIN_ID: &str = "neutron-666";
 const DEFAULT_GAS_ADJUSTMENT: f64 = 1.2;
+pub const NEUTRON_MIN_GAS_PRICE: u128 = 2_500;
+
+#[derive(Debug, PartialEq)]
+pub struct BaseApp {
+    id: u64,
+    fee_denom: String,
+    chain_id: String,
+    address_prefix: String,
+    default_gas_adjustment: f64,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct SlinkyPrices {
+    pub base: String,
+    pub quote: String,
+    pub price: u128,
+}
+
+impl BaseApp {
+    pub fn new(
+        fee_denom: &str,
+        chain_id: &str,
+        address_prefix: &str,
+        default_gas_adjustment: f64,
+    ) -> Self {
+        let id = unsafe { InitTestEnv() };
+        BaseApp {
+            id,
+            fee_denom: fee_denom.to_string(),
+            chain_id: chain_id.to_string(),
+            address_prefix: address_prefix.to_string(),
+            default_gas_adjustment,
+        }
+    }
+
+    /// Increase the time of the blockchain by the given number of seconds.
+    pub fn increase_time(&self, seconds: u64) {
+        unsafe {
+            IncreaseTime(self.id, seconds.try_into().unwrap());
+        }
+    }
+
+    /// Sets prices in slinky
+    pub fn set_slinky_prices(&self, prices: &[SlinkyPrices]) {
+        let prices_json = serde_json::to_string(&prices)
+            .map_err(EncodeError::JsonEncodeError)
+            .unwrap();
+        redefine_as_go_string!(prices_json);
+
+        unsafe {
+            SetSlinkyPrices(self.id, prices_json);
+        }
+    }
+
+    /// Get the first validator address
+    pub fn get_first_validator_address(&self) -> RunnerResult<String> {
+        let addr = unsafe {
+            let addr = GetValidatorAddress(self.id, 0);
+            CString::from_raw(addr)
+        }
+        .to_str()
+        .map_err(DecodeError::Utf8Error)?
+        .to_string();
+
+        Ok(addr)
+    }
+
+    /// Get the first validator private key
+    pub fn get_first_validator_private_key(&self) -> RunnerResult<String> {
+        let pkey = unsafe {
+            let pkey = GetValidatorPrivateKey(self.id, 0);
+            CString::from_raw(pkey)
+        }
+        .to_str()
+        .map_err(DecodeError::Utf8Error)?
+        .to_string();
+
+        Ok(pkey)
+    }
+
+    /// Get the first validator signing account
+    pub fn get_first_validator_signing_account(
+        &self,
+        denom: String,
+        gas_adjustment: f64,
+    ) -> RunnerResult<SigningAccount> {
+        let pkey = unsafe {
+            let pkey = GetValidatorPrivateKey(self.id, 0);
+            CString::from_raw(pkey)
+        }
+        .to_str()
+        .map_err(DecodeError::Utf8Error)?
+        .to_string();
+
+        let secp256k1_priv = BASE64_STANDARD
+            .decode(pkey)
+            .map_err(DecodeError::Base64DecodeError)?;
+
+        let signing_key = SigningKey::from_slice(&secp256k1_priv).unwrap();
+
+        let validator = SigningAccount::new(
+            self.address_prefix.to_string(),
+            signing_key,
+            FeeSetting::Auto {
+                gas_price: Coin::new(NEUTRON_MIN_GAS_PRICE, denom),
+                gas_adjustment,
+            },
+        );
+
+        Ok(validator)
+    }
+
+    /// Get the current block time
+    pub fn get_block_time_nanos(&self) -> i64 {
+        unsafe { GetBlockTime(self.id) }
+    }
+
+    /// Get the current block height
+    pub fn get_block_height(&self) -> i64 {
+        unsafe { GetBlockHeight(self.id) }
+    }
+    /// Initialize account with initial balance of any coins.
+    /// This function mints new coins and send to newly created account
+    pub fn init_account(&self, coins: &[Coin]) -> RunnerResult<SigningAccount> {
+        let mut coins = coins.to_vec();
+
+        // invalid coins if denom are unsorted
+        coins.sort_by(|a, b| a.denom.cmp(&b.denom));
+
+        let coins_json = serde_json::to_string(&coins).map_err(EncodeError::JsonEncodeError)?;
+        redefine_as_go_string!(coins_json);
+
+        let empty_tx = "".to_string();
+        redefine_as_go_string!(empty_tx);
+
+        let base64_priv = unsafe {
+            let addr = InitAccount(self.id, coins_json);
+            FinalizeBlock(self.id, empty_tx);
+            CString::from_raw(addr)
+        }
+        .to_str()
+        .map_err(DecodeError::Utf8Error)?
+        .to_string();
+
+        let secp256k1_priv = BASE64_STANDARD
+            .decode(base64_priv)
+            .map_err(DecodeError::Base64DecodeError)?;
+
+        let signing_key = SigningKey::from_slice(&secp256k1_priv).map_err(|e| {
+            let msg = e.to_string();
+            DecodeError::SigningKeyDecodeError { msg }
+        })?;
+
+        Ok(SigningAccount::new(
+            self.address_prefix.clone(),
+            signing_key,
+            FeeSetting::Auto {
+                gas_price: Coin::new(NEUTRON_MIN_GAS_PRICE, self.fee_denom.clone()),
+                gas_adjustment: self.default_gas_adjustment,
+            },
+        ))
+    }
+
+    /// Convenience function to create multiple accounts with the same
+    /// Initial coins balance
+    pub fn init_accounts(&self, coins: &[Coin], count: u64) -> RunnerResult<Vec<SigningAccount>> {
+        (0..count).map(|_| self.init_account(coins)).collect()
+    }
+
+    fn create_signed_tx<I>(
+        &self,
+        msgs: I,
+        signer: &SigningAccount,
+        fee: Fee,
+    ) -> RunnerResult<Vec<u8>>
+    where
+        I: IntoIterator<Item = cosmrs::Any>,
+    {
+        let tx_body = tx::Body::new(msgs, "", 0u32);
+        let addr = signer.address();
+
+        redefine_as_go_string!(addr);
+
+        let seq = unsafe { AccountSequence(self.id, addr) };
+
+        let account_number = unsafe { AccountNumber(self.id, addr) };
+
+        let signer_info = SignerInfo::single_direct(Some(signer.public_key()), seq);
+        let auth_info = signer_info.auth_info(fee);
+        let sign_doc = tx::SignDoc::new(
+            &tx_body,
+            &auth_info,
+            &(self
+                .chain_id
+                .parse()
+                .expect("parse const str of chain id should never fail")),
+            account_number,
+        )
+        .map_err(|e| match e.downcast::<prost::EncodeError>() {
+            Ok(encode_err) => EncodeError::ProtoEncodeError(encode_err),
+            Err(e) => panic!("expect `prost::EncodeError` but got {:?}", e),
+        })?;
+
+        let tx_raw = sign_doc.sign(signer.signing_key()).unwrap();
+
+        tx_raw
+            .to_bytes()
+            .map_err(|e| match e.downcast::<prost::EncodeError>() {
+                Ok(encode_err) => EncodeError::ProtoEncodeError(encode_err),
+                Err(e) => panic!("expect `prost::EncodeError` but got {:?}", e),
+            })
+            .map_err(RunnerError::EncodeError)
+    }
+
+    pub fn simulate_tx<I>(
+        &self,
+        msgs: I,
+        signer: &SigningAccount,
+    ) -> RunnerResult<cosmrs::proto::cosmos::base::abci::v1beta1::GasInfo>
+    where
+        I: IntoIterator<Item = cosmrs::Any>,
+    {
+        let zero_fee = Fee::from_amount_and_gas(
+            cosmrs::Coin {
+                denom: self.fee_denom.parse().unwrap(),
+                amount: NEUTRON_MIN_GAS_PRICE,
+            },
+            0u64,
+        );
+
+        let tx = self.create_signed_tx(msgs, signer, zero_fee)?;
+        let base64_tx_bytes = BASE64_STANDARD.encode(tx);
+
+        redefine_as_go_string!(base64_tx_bytes);
+
+        unsafe {
+            let res = Simulate(self.id, base64_tx_bytes);
+            let res = RawResult::from_non_null_ptr(res).into_result()?;
+
+            cosmrs::proto::cosmos::base::abci::v1beta1::GasInfo::decode(res.as_slice())
+                .map_err(DecodeError::ProtoDecodeError)
+                .map_err(RunnerError::DecodeError)
+        }
+    }
+    fn estimate_fee<I>(&self, msgs: I, signer: &SigningAccount) -> RunnerResult<Fee>
+    where
+        I: IntoIterator<Item = cosmrs::Any>,
+    {
+        let res = match &signer.fee_setting() {
+            FeeSetting::Auto {
+                gas_price,
+                gas_adjustment,
+            } => {
+                let gas_info = self.simulate_tx(msgs, signer)?;
+                let gas_limit = ((gas_info.gas_used as f64) * (gas_adjustment)).ceil() as u64;
+
+                let amount = cosmrs::Coin {
+                    denom: self.fee_denom.parse().unwrap(),
+                    amount: (((gas_limit as f64)
+                        * (gas_price.amount.to_string().parse::<u64>()? as f64))
+                        .ceil() as u64)
+                        .into(),
+                };
+                Ok(Fee::from_amount_and_gas(amount, gas_limit))
+            }
+            FeeSetting::Custom { .. } => {
+                panic!("estimate fee is a private function and should never be called when fee_setting is Custom");
+            }
+        };
+
+        res
+    }
+
+    /// Set parameter set for a given subspace.
+    pub fn set_param_set(&self, subspace: &str, pset: impl Into<Any>) -> RunnerResult<()> {
+        unsafe {
+            let pset = Message::encode_to_vec(&pset.into());
+            let pset = BASE64_STANDARD.encode(pset);
+            redefine_as_go_string!(pset);
+            redefine_as_go_string!(subspace);
+            let res = SetParamSet(self.id, subspace, pset);
+
+            // Just move one block forward
+            IncreaseTime(self.id, 1u64.try_into().unwrap());
+
+            // returns empty bytes if success
+            RawResult::from_non_null_ptr(res).into_result()?;
+            Ok(())
+        }
+    }
+
+    /// Get parameter set for a given subspace.
+    pub fn get_param_set<P: Message + Default>(
+        &self,
+        subspace: &str,
+        type_url: &str,
+    ) -> RunnerResult<P> {
+        unsafe {
+            redefine_as_go_string!(subspace);
+            redefine_as_go_string!(type_url);
+            let pset = GetParamSet(self.id, subspace, type_url);
+            let pset = RawResult::from_non_null_ptr(pset).into_result()?;
+            let pset = P::decode(pset.as_slice()).map_err(DecodeError::ProtoDecodeError)?;
+            Ok(pset)
+        }
+    }
+}
+
+impl<'a> Runner<'a> for BaseApp {
+    fn execute_multiple<M, R>(
+        &self,
+        msgs: &[(M, &str)],
+        signer: &SigningAccount,
+    ) -> RunnerExecuteResult<R>
+    where
+        M: ::prost::Message,
+        R: ::prost::Message + Default,
+    {
+        let msgs = msgs
+            .iter()
+            .map(|(msg, type_url)| {
+                let mut buf = Vec::new();
+                M::encode(msg, &mut buf).map_err(EncodeError::ProtoEncodeError)?;
+
+                Ok(cosmrs::Any {
+                    type_url: type_url.to_string(),
+                    value: buf,
+                })
+            })
+            .collect::<Result<Vec<cosmrs::Any>, RunnerError>>()?;
+
+        self.execute_multiple_raw(msgs, signer)
+    }
+
+    fn execute_multiple_raw<R>(
+        &self,
+        msgs: Vec<cosmrs::Any>,
+        signer: &SigningAccount,
+    ) -> RunnerExecuteResult<R>
+    where
+        R: ::prost::Message + Default,
+    {
+        unsafe {
+            let fee = match &signer.fee_setting() {
+                FeeSetting::Auto { .. } => self.estimate_fee(msgs.clone(), signer)?,
+                FeeSetting::Custom { amount, gas_limit } => Fee::from_amount_and_gas(
+                    cosmrs::Coin {
+                        denom: amount.denom.parse().unwrap(),
+                        amount: amount.amount.to_string().parse().unwrap(),
+                    },
+                    *gas_limit,
+                ),
+            };
+
+            let tx = self.create_signed_tx(msgs.clone(), signer, fee)?;
+            let base64_tx_bytes = BASE64_STANDARD.encode(tx);
+
+            redefine_as_go_string!(base64_tx_bytes);
+
+            let res = FinalizeBlock(self.id, base64_tx_bytes);
+            let res = RawResult::from_non_null_ptr(res).into_result()?;
+
+            let res = ResponseFinalizeBlock::decode(res.as_slice())
+                .unwrap()
+                .try_into();
+
+            // println!("{:#?}", res);
+
+            res
+        }
+    }
+
+    fn query<Q, R>(&self, path: &str, q: &Q) -> RunnerResult<R>
+    where
+        Q: ::prost::Message,
+        R: ::prost::Message + Default,
+    {
+        let mut buf = Vec::new();
+
+        Q::encode(q, &mut buf).map_err(EncodeError::ProtoEncodeError)?;
+
+        let base64_query_msg_bytes = BASE64_STANDARD.encode(buf);
+
+        redefine_as_go_string!(path);
+        redefine_as_go_string!(base64_query_msg_bytes);
+
+        unsafe {
+            let res = Query(self.id, path, base64_query_msg_bytes);
+            let res = RawResult::from_non_null_ptr(res).into_result()?;
+            R::decode(res.as_slice())
+                .map_err(DecodeError::ProtoDecodeError)
+                .map_err(RunnerError::DecodeError)
+        }
+    }
+
+    fn execute<M, R>(
+        &self,
+        msg: M,
+        type_url: &str,
+        signer: &SigningAccount,
+    ) -> RunnerExecuteResult<R>
+    where
+        M: prost::Message,
+        R: prost::Message + Default,
+    {
+        self.execute_multiple(&[(msg, type_url)], signer)
+    }
+
+    fn execute_cosmos_msgs<S>(
+        &self,
+        msgs: &[cosmwasm_std::CosmosMsg],
+        signer: &SigningAccount,
+    ) -> RunnerExecuteResult<S>
+    where
+        S: prost::Message + Default,
+    {
+        let msgs = msgs
+            .iter()
+            .map(|msg| match msg {
+                cosmwasm_std::CosmosMsg::Bank(msg) => crate::utils::bank_msg_to_any(msg, signer),
+                #[allow(deprecated)]
+                cosmwasm_std::CosmosMsg::Stargate { type_url, value } => Ok(cosmrs::Any {
+                    type_url: type_url.clone(),
+                    value: value.to_vec(),
+                }),
+                cosmwasm_std::CosmosMsg::Any(msg) => Ok(cosmrs::Any {
+                    type_url: msg.type_url.clone(),
+                    value: msg.value.to_vec(),
+                }),
+                cosmwasm_std::CosmosMsg::Wasm(msg) => crate::utils::wasm_msg_to_any(msg, signer),
+                _ => std::todo!("unsupported cosmos msg variant"),
+            })
+            .collect::<Result<Vec<_>, RunnerError>>()?;
+
+        self.execute_multiple_raw(msgs, signer)
+    }
+}
 
 #[derive(Debug, PartialEq)]
 pub struct NeutronTestApp {
@@ -33,6 +486,11 @@ impl NeutronTestApp {
                 DEFAULT_GAS_ADJUSTMENT,
             ),
         }
+    }
+
+    /// Get the current block time as a timestamp
+    pub fn get_block_timestamp(&self) -> Timestamp {
+        Timestamp::from_nanos(self.inner.get_block_time_nanos().try_into().unwrap())
     }
 
     /// Get the current block time in nanoseconds
@@ -73,6 +531,10 @@ impl NeutronTestApp {
     /// Increase the time of the blockchain by the given number of seconds.
     pub fn increase_time(&self, seconds: u64) {
         self.inner.increase_time(seconds)
+    }
+    /// Set the slinky prices
+    pub fn set_slinky_prices(&self, prices: &[SlinkyPrices]) {
+        self.inner.set_slinky_prices(prices)
     }
 
     /// Initialize account with initial balance of any coins.
@@ -156,10 +618,10 @@ mod tests {
     use crate::module::Wasm;
     use crate::runner::app::NeutronTestApp;
 
-    use test_tube_ntrn::account::Account;
-    use test_tube_ntrn::module::Module;
-    use test_tube_ntrn::runner::*;
-    use test_tube_ntrn::ExecuteResponse;
+    use crate::account::Account;
+    use crate::module::Module;
+    use crate::runner::*;
+    use crate::ExecuteResponse;
 
     #[test]
     fn test_init_account() {
@@ -304,8 +766,8 @@ mod tests {
         let accs = app
             .init_accounts(
                 &[
-                    Coin::new(1_000_000_000_000, "uatom"),
-                    Coin::new(1_000_000_000_000, "untrn"),
+                    Coin::new(1_000_000_000_000u128, "uatom"),
+                    Coin::new(1_000_000_000_000u128, "untrn"),
                 ],
                 2,
             )

--- a/packages/neutron-test-tube/src/runner/error.rs
+++ b/packages/neutron-test-tube/src/runner/error.rs
@@ -1,0 +1,112 @@
+use cosmrs::rpc::error::Error as TendermintRpcError;
+use cosmrs::tendermint::Error as TendermintError;
+use cosmrs::ErrorReport;
+use std::num::ParseIntError;
+use std::str::Utf8Error;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum RunnerError {
+    #[error("unable to encode request")]
+    EncodeError(#[from] EncodeError),
+
+    #[error("unable to decode response")]
+    DecodeError(#[from] DecodeError),
+
+    #[error("unable to parse integer precisely")]
+    ParseIntError(#[from] ParseIntError),
+
+    #[error("query error: {}", .msg)]
+    QueryError { msg: String },
+
+    #[error("execute error: {}", .msg)]
+    ExecuteError { msg: String },
+
+    #[error("{0}")]
+    GenericError(String),
+
+    #[error("{0}")]
+    ErrorReport(#[from] ErrorReport),
+
+    #[error("{0}")]
+    Tendermint(#[from] TendermintError),
+
+    #[error("{0}")]
+    TendermintRpc(#[from] TendermintRpcError),
+}
+
+impl PartialEq for RunnerError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (RunnerError::EncodeError(a), RunnerError::EncodeError(b)) => a == b,
+            (RunnerError::DecodeError(a), RunnerError::DecodeError(b)) => a == b,
+            (RunnerError::QueryError { msg: a }, RunnerError::QueryError { msg: b }) => a == b,
+            (RunnerError::ExecuteError { msg: a }, RunnerError::ExecuteError { msg: b }) => a == b,
+            (RunnerError::ErrorReport(a), RunnerError::ErrorReport(b)) => {
+                a.to_string() == b.to_string()
+            }
+            (RunnerError::Tendermint(a), RunnerError::Tendermint(b)) => {
+                a.to_string() == b.to_string()
+            }
+            (RunnerError::TendermintRpc(a), RunnerError::TendermintRpc(b)) => a.0 == b.0,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum DecodeError {
+    #[error("invalid utf8 bytes")]
+    Utf8Error(#[from] Utf8Error),
+
+    #[error("invalid protobuf")]
+    ProtoDecodeError(#[from] prost::DecodeError),
+
+    #[error("invalid json")]
+    JsonDecodeError(#[from] serde_json::Error),
+
+    #[error("invalid base64")]
+    Base64DecodeError(#[from] base64::DecodeError),
+
+    #[error("invalid signing key")]
+    SigningKeyDecodeError { msg: String },
+}
+
+impl PartialEq for DecodeError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (DecodeError::Utf8Error(a), DecodeError::Utf8Error(b)) => a == b,
+            (DecodeError::ProtoDecodeError(a), DecodeError::ProtoDecodeError(b)) => a == b,
+            (DecodeError::JsonDecodeError(a), DecodeError::JsonDecodeError(b)) => {
+                a.to_string() == b.to_string()
+            }
+            (DecodeError::Base64DecodeError(a), DecodeError::Base64DecodeError(b)) => a == b,
+            (
+                DecodeError::SigningKeyDecodeError { msg: a },
+                DecodeError::SigningKeyDecodeError { msg: b },
+            ) => a == b,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum EncodeError {
+    #[error("invalid protobuf")]
+    ProtoEncodeError(#[from] prost::EncodeError),
+
+    #[error("unable to encode json")]
+    JsonEncodeError(#[from] serde_json::Error),
+}
+
+impl PartialEq for EncodeError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (EncodeError::ProtoEncodeError(a), EncodeError::ProtoEncodeError(b)) => a == b,
+            (EncodeError::JsonEncodeError(a), EncodeError::JsonEncodeError(b)) => {
+                a.to_string() == b.to_string()
+            }
+            _ => false,
+        }
+    }
+}

--- a/packages/neutron-test-tube/src/runner/mod.rs
+++ b/packages/neutron-test-tube/src/runner/mod.rs
@@ -6,7 +6,6 @@ mod tests {
     use crate::{Bank, Wasm};
 
     use super::app::NeutronTestApp;
-    use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
     use base64::Engine;
     use cosmwasm_std::{to_json_binary, BankMsg, Coin, CosmosMsg, Empty, Event, WasmMsg};
     use cw1_whitelist::msg::{ExecuteMsg, InstantiateMsg};
@@ -56,9 +55,8 @@ mod tests {
 
     #[test]
     fn test_raw_result_ptr_with_0_bytes_in_content_should_not_error() {
-        let base64_string = BASE64_STANDARD
-            .decode([vec![0u8], vec![0u8]].concat())
-            .unwrap();
+        let base64_string =
+            base64::engine::general_purpose::STANDARD.encode([vec![0u8], vec![0u8]].concat());
         let res = unsafe { RawResult::from_ptr(CString::new(base64_string).unwrap().into_raw()) }
             .unwrap()
             .into_result()

--- a/packages/neutron-test-tube/src/runner/mod.rs
+++ b/packages/neutron-test-tube/src/runner/mod.rs
@@ -1,11 +1,87 @@
+use cosmwasm_std::CosmosMsg;
+
+use crate::account::SigningAccount;
+use crate::runner::result::{RunnerExecuteResult, RunnerResult};
+use crate::utils::{bank_msg_to_any, wasm_msg_to_any};
+use crate::RunnerError;
+
 pub mod app;
+pub mod error;
+pub mod result;
+
+pub trait Runner<'a> {
+    fn execute<M, R>(
+        &self,
+        msg: M,
+        type_url: &str,
+        signer: &SigningAccount,
+    ) -> RunnerExecuteResult<R>
+    where
+        M: ::prost::Message,
+        R: ::prost::Message + Default,
+    {
+        self.execute_multiple(&[(msg, type_url)], signer)
+    }
+
+    fn execute_multiple<M, R>(
+        &self,
+        msgs: &[(M, &str)],
+        signer: &SigningAccount,
+    ) -> RunnerExecuteResult<R>
+    where
+        M: ::prost::Message,
+        R: ::prost::Message + Default;
+
+    fn execute_multiple_raw<R>(
+        &self,
+        msgs: Vec<cosmrs::Any>,
+        signer: &SigningAccount,
+    ) -> RunnerExecuteResult<R>
+    where
+        R: ::prost::Message + Default;
+
+    fn execute_cosmos_msgs<S>(
+        &self,
+        msgs: &[CosmosMsg],
+        signer: &SigningAccount,
+    ) -> RunnerExecuteResult<S>
+    where
+        S: ::prost::Message + Default,
+    {
+        let msgs = msgs
+            .iter()
+            .map(|msg| match msg {
+                CosmosMsg::Bank(msg) => bank_msg_to_any(msg, signer),
+                #[allow(deprecated)]
+                CosmosMsg::Stargate { type_url, value } => Ok(cosmrs::Any {
+                    type_url: type_url.clone(),
+                    value: value.to_vec(),
+                }),
+                CosmosMsg::Any(msg) => Ok(cosmrs::Any {
+                    type_url: msg.type_url.clone(),
+                    value: msg.value.to_vec(),
+                }),
+                CosmosMsg::Wasm(msg) => wasm_msg_to_any(msg, signer),
+                _ => todo!("unsupported cosmos msg variant"),
+            })
+            .collect::<Result<Vec<_>, RunnerError>>()?;
+
+        self.execute_multiple_raw(msgs, signer)
+    }
+
+    fn query<Q, R>(&self, path: &str, query: &Q) -> RunnerResult<R>
+    where
+        Q: ::prost::Message,
+        R: ::prost::Message + Default;
+}
 
 #[cfg(test)]
 mod tests {
 
-    use crate::{Bank, Wasm};
-
     use super::app::NeutronTestApp;
+    use crate::runner::error::RunnerError::QueryError;
+    use crate::runner::result::RawResult;
+    use crate::{Account, Bank, Module, Runner, Wasm};
     use base64::Engine;
     use cosmwasm_std::{to_json_binary, BankMsg, Coin, CosmosMsg, Empty, Event, WasmMsg};
     use cw1_whitelist::msg::{ExecuteMsg, InstantiateMsg};
@@ -18,11 +94,6 @@ mod tests {
         cosmos::bank::v1beta1::{MsgSendResponse, QueryBalanceRequest},
         cosmwasm::wasm::v1::{MsgExecuteContractResponse, MsgInstantiateContractResponse},
     };
-    use test_tube_ntrn::account::Account;
-    use test_tube_ntrn::runner::error::RunnerError::QueryError;
-    use test_tube_ntrn::runner::result::RawResult;
-    use test_tube_ntrn::runner::Runner;
-    use test_tube_ntrn::Module;
 
     #[derive(::prost::Message)]
     struct AdhocRandomQueryRequest {
@@ -69,14 +140,14 @@ mod tests {
     fn test_execute_cosmos_msgs() {
         let app = NeutronTestApp::new();
         let signer = app
-            .init_account(&[Coin::new(10000000000, "untrn")])
+            .init_account(&[Coin::new(10_000_000_000u128, "untrn")])
             .unwrap();
 
         let bank = Bank::new(&app);
 
         // BankMsg::Send
         let to = app.init_account(&[]).unwrap();
-        let coin = Coin::new(100, "untrn");
+        let coin = Coin::new(100u128, "untrn");
         let send_msg = CosmosMsg::Bank(BankMsg::Send {
             to_address: to.address(),
             amount: vec![coin],

--- a/packages/neutron-test-tube/src/runner/mod.rs
+++ b/packages/neutron-test-tube/src/runner/mod.rs
@@ -87,10 +87,10 @@ mod tests {
     use cw1_whitelist::msg::{ExecuteMsg, InstantiateMsg};
     use std::ffi::CString;
 
-    use margined_neutron_std::types::osmosis::tokenfactory::v1beta1::{
+    use neutron_std::types::osmosis::tokenfactory::v1beta1::{
         MsgCreateDenom, MsgCreateDenomResponse,
     };
-    use margined_neutron_std::types::{
+    use neutron_std::types::{
         cosmos::bank::v1beta1::{MsgSendResponse, QueryBalanceRequest},
         cosmwasm::wasm::v1::{MsgExecuteContractResponse, MsgInstantiateContractResponse},
     };

--- a/packages/neutron-test-tube/src/runner/result.rs
+++ b/packages/neutron-test-tube/src/runner/result.rs
@@ -38,7 +38,7 @@ where
             .msg_responses
             // since this tx contains exactly 1 msg
             // when getting none of them, that means error
-            .get(0)
+            .first()
             .ok_or(RunnerError::ExecuteError { msg: res.log })?;
 
         let data = R::decode(msg_data.value.as_slice()).map_err(DecodeError::ProtoDecodeError)?;
@@ -94,7 +94,7 @@ where
             .msg_responses
             // since this tx contains exactly 1 msg
             // when getting none of them, that means error
-            .get(0)
+            .first()
             .ok_or(RunnerError::ExecuteError { msg: res.log })?;
 
         let data = R::decode(msg_data.value.as_slice()).map_err(DecodeError::ProtoDecodeError)?;
@@ -143,13 +143,29 @@ where
 
     fn try_from(res: ResponseFinalizeBlock) -> Result<Self, Self::Error> {
         // NOTE: this actually returns multiple transactions
-        let tx = res
-            .tx_results
-            .first()
-            .or_else(|| res.tx_results.get(1))
-            .ok_or(RunnerError::ExecuteError {
+        // let tx = res
+        //     .tx_results
+        //     .first()
+        //     .or_else(|| res.tx_results.get(1))
+        //     .ok_or(RunnerError::ExecuteError {
+        //         msg: "No tx results".to_string(),
+        //     })?;
+        // let tx = res
+        //     .tx_results
+        //     .get(1) // Access the second item directly (index 1)
+        //     .ok_or(RunnerError::ExecuteError {
+        //         msg: "No second tx result".to_string(),
+        //     })?;
+
+        let tx = if res.tx_results.len() < 2 {
+            res.tx_results.first().ok_or(RunnerError::ExecuteError {
                 msg: "No tx results".to_string(),
-            })?;
+            })?
+        } else {
+            res.tx_results.get(1).ok_or(RunnerError::ExecuteError {
+                msg: "No tx results".to_string(),
+            })?
+        };
 
         let tx_msg_data =
             TxMsgData::decode(tx.data.as_ref()).map_err(DecodeError::ProtoDecodeError)?;
@@ -160,7 +176,7 @@ where
             // the gas spend transaction as mentioned above
             // this needs some thought for supporting more than
             // one transaction per block
-            .get(0)
+            .first()
             .ok_or(RunnerError::ExecuteError {
                 msg: tx.log.clone(),
             })?;

--- a/packages/neutron-test-tube/src/utils.rs
+++ b/packages/neutron-test-tube/src/utils.rs
@@ -1,0 +1,131 @@
+use cosmrs::proto::{
+    cosmos::bank::v1beta1::MsgSend,
+    cosmwasm::wasm::v1::{
+        MsgClearAdmin, MsgExecuteContract, MsgInstantiateContract, MsgMigrateContract,
+        MsgUpdateAdmin,
+    },
+};
+use cosmwasm_std::{BankMsg, Coin, WasmMsg};
+use prost::Message;
+
+use crate::{Account, EncodeError, RunnerError, SigningAccount};
+
+pub fn coins_to_proto(coins: &[Coin]) -> Vec<cosmrs::proto::cosmos::base::v1beta1::Coin> {
+    let mut coins = coins.to_vec();
+    coins.sort_by(|a, b| a.denom.cmp(&b.denom));
+    coins
+        .iter()
+        .map(|c| cosmrs::proto::cosmos::base::v1beta1::Coin {
+            denom: c.denom.parse().unwrap(),
+            amount: format!("{}", c.amount.to_string()),
+        })
+        .collect()
+}
+
+pub fn proto_coin_to_coin(proto_coin: &cosmrs::proto::cosmos::base::v1beta1::Coin) -> Coin {
+    Coin {
+        denom: proto_coin.denom.clone(),
+        amount: proto_coin.amount.parse().unwrap(),
+    }
+}
+
+pub fn proto_coins_to_coins(coins: &[cosmrs::proto::cosmos::base::v1beta1::Coin]) -> Vec<Coin> {
+    coins.iter().map(proto_coin_to_coin).collect()
+}
+
+pub fn msg_to_any<T: Message>(type_url: &str, msg: &T) -> Result<cosmrs::Any, RunnerError> {
+    let mut buf = Vec::new();
+    msg.encode(&mut buf)
+        .map_err(EncodeError::ProtoEncodeError)?;
+
+    Ok(cosmrs::Any {
+        type_url: type_url.to_owned(),
+        value: buf,
+    })
+}
+
+pub fn bank_msg_to_any(msg: &BankMsg, signer: &SigningAccount) -> Result<cosmrs::Any, RunnerError> {
+    match msg {
+        BankMsg::Send { to_address, amount } => {
+            let type_url = "/cosmos.bank.v1beta1.MsgSend";
+            let msg = MsgSend {
+                from_address: signer.address(),
+                to_address: to_address.to_string(),
+                amount: coins_to_proto(amount),
+            };
+            msg_to_any(type_url, &msg)
+        }
+        _ => {
+            todo!() // TODO: Can't find BurnMsg...?
+        }
+    }
+}
+
+pub fn wasm_msg_to_any(msg: &WasmMsg, signer: &SigningAccount) -> Result<cosmrs::Any, RunnerError> {
+    match msg {
+        WasmMsg::Execute {
+            contract_addr,
+            msg,
+            funds,
+        } => msg_to_any(
+            "/cosmwasm.wasm.v1.MsgExecuteContract",
+            &MsgExecuteContract {
+                contract: contract_addr.clone(),
+                funds: coins_to_proto(funds),
+                sender: signer.address(),
+                msg: msg.to_vec(),
+            },
+        ),
+        WasmMsg::Instantiate {
+            admin,
+            code_id,
+            msg,
+            funds,
+            label,
+        } => msg_to_any(
+            "/cosmwasm.wasm.v1.MsgInstantiateContract",
+            &MsgInstantiateContract {
+                sender: signer.address(),
+                admin: admin.clone().unwrap_or_default(),
+                code_id: *code_id,
+                label: label.clone(),
+                msg: msg.to_vec(),
+                funds: coins_to_proto(funds),
+            },
+        ),
+        WasmMsg::Migrate {
+            contract_addr,
+            new_code_id,
+            msg,
+        } => msg_to_any(
+            "/cosmwasm.wasm.v1.MsgMigrateContract",
+            &MsgMigrateContract {
+                contract: contract_addr.clone(),
+                sender: signer.address(),
+                code_id: *new_code_id,
+                msg: msg.to_vec(),
+            },
+        ),
+        WasmMsg::UpdateAdmin {
+            contract_addr,
+            admin,
+        } => msg_to_any(
+            "/cosmwasm.wasm.v1.MsgUpdateAdmin",
+            &MsgUpdateAdmin {
+                contract: contract_addr.clone(),
+                sender: signer.address(),
+                new_admin: admin.clone(),
+            },
+        ),
+        WasmMsg::ClearAdmin { contract_addr } => msg_to_any(
+            "/cosmwasm.wasm.v1.MsgClearAdmin",
+            &MsgClearAdmin {
+                contract: contract_addr.clone(),
+                sender: signer.address(),
+            },
+        ),
+        _ => Err(RunnerError::ExecuteError {
+            msg: "Unsupported WasmMsg".to_string(),
+        }),
+    }
+}

--- a/packages/test-tube/Cargo.toml
+++ b/packages/test-tube/Cargo.toml
@@ -4,7 +4,7 @@ edition     = "2021"
 license     = "MIT OR Apache-2.0"
 name        = "test-tube-ntrn"
 repository  = "https://github.com/margined-protocol/test-tube"
-version     = "0.1.0"
+version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/test-tube/Cargo.toml
+++ b/packages/test-tube/Cargo.toml
@@ -10,14 +10,14 @@ version     = "0.1.1"
 
 [dependencies]
 base64           = "0.21.5"
-cosmrs           = { version = "0.15.0", features = [ "cosmwasm", "rpc" ] }
+cosmrs           = { version = "0.23.0", features = [ "cosmwasm", "rpc" ], git = "https://github.com/permissionlessweb/cosmos-rust" }
 cosmwasm-std     = { version = "1.5.4", features = [ "abort", "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "iterator", "stargate" ] }
-prost            = "0.12.4"
-serde            = "1.0.144"
-serde_json       = "1.0.85"
-tendermint-proto = "0.32.0"
-thiserror        = "1.0.34"
+tendermint-proto =  {version = "0.40.4", git = "https://github.com/permissionlessweb/tendermint-rs" }
+prost                = { version = "0.14.1", features = [ "derive" ] }
+serde                = { version = "1.0.144" }
+serde_json           = { version = "1.0.85" }
+thiserror            = { version = "1.0.34" }
 
 [dev-dependencies]
-cw1-whitelist = "0.15.0"
-rayon         = "1.5.3"
+cw1-whitelist = { version = "3.0.0", git = "https://github.com/permissionlessweb/cw-plus", branch = "bump/v3" }
+rayon         = { version = "1.5.3" }

--- a/packages/test-tube/Cargo.toml
+++ b/packages/test-tube/Cargo.toml
@@ -10,14 +10,14 @@ version     = "0.1.1"
 
 [dependencies]
 base64           = "0.21.5"
-cosmrs           = { path = "../../../cosmos-rust/cosmrs" }
-cosmwasm-std     = { version = "1.5.4", features = [ "abort", "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "iterator", "stargate" ] }
-tendermint-proto =  { path = "../../../tendermint-rs/proto" }
+cosmrs = { git = "https://github.com/permissionlessweb/cosmos-rust", branch = "main" }
+cosmwasm-std = { git = "https://github.com/permissionlessweb/cosmwasm", branch = "mvp", features = ["abort", "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "iterator", "stargate"] }
+tendermint-proto = { git = "https://github.com/permissionlessweb/tendermint-rs", branch = "main" }
 prost                = { version = "0.14.1", features = [ "derive" ] }
 serde                = { version = "1.0.144" }
 serde_json           = { version = "1.0.85" }
 thiserror            = { version = "1.0.34" }
 
 [dev-dependencies]
-cw1-whitelist = { path = "../../../cw-plus/contracts/cw1-whitelist" }
+cw1-whitelist = { git = "https://github.com/permissionlessweb/cw-plus", branch = "main" }
 rayon         = { version = "1.5.3" }

--- a/packages/test-tube/Cargo.toml
+++ b/packages/test-tube/Cargo.toml
@@ -19,5 +19,5 @@ serde_json           = { version = "1.0.85" }
 thiserror            = { version = "1.0.34" }
 
 [dev-dependencies]
-cw1-whitelist = { version = "3.0.0", git = "https://github.com/permissionlessweb/cw-plus", branch = "bump/v3" }
+cw1-whitelist = { version = "3.0.0", git = "https://github.com/permissionlessweb/cw-plus" }
 rayon         = { version = "1.5.3" }

--- a/packages/test-tube/Cargo.toml
+++ b/packages/test-tube/Cargo.toml
@@ -10,14 +10,14 @@ version     = "0.1.1"
 
 [dependencies]
 base64           = "0.21.5"
-cosmrs           = { version = "0.23.0", features = [ "cosmwasm", "rpc" ], git = "https://github.com/permissionlessweb/cosmos-rust" }
+cosmrs           = { path = "../../../cosmos-rust/cosmrs" }
 cosmwasm-std     = { version = "1.5.4", features = [ "abort", "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "iterator", "stargate" ] }
-tendermint-proto =  {version = "0.40.4", git = "https://github.com/permissionlessweb/tendermint-rs" }
+tendermint-proto =  { path = "../../../tendermint-rs/proto" }
 prost                = { version = "0.14.1", features = [ "derive" ] }
 serde                = { version = "1.0.144" }
 serde_json           = { version = "1.0.85" }
 thiserror            = { version = "1.0.34" }
 
 [dev-dependencies]
-cw1-whitelist = { version = "3.0.0", git = "https://github.com/permissionlessweb/cw-plus" }
+cw1-whitelist = { path = "../../../cw-plus/contracts/cw1-whitelist" }
 rayon         = { version = "1.5.3" }

--- a/packages/test-tube/src/bindings.rs
+++ b/packages/test-tube/src/bindings.rs
@@ -254,11 +254,14 @@ extern "C" {
     pub fn GetValidatorAddress(envId: GoUint64, n: GoInt32) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    pub fn GetValidatorPrivateKey(envId: GoUint64) -> *mut ::std::os::raw::c_char;
+    pub fn GetValidatorPrivateKey(envId: GoUint64, n: GoInt32) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
     pub fn GetBlockTime(envId: GoUint64) -> GoInt64;
 }
 extern "C" {
     pub fn GetBlockHeight(envId: GoUint64) -> GoInt64;
+}
+extern "C" {
+    pub fn CleanUp(envId: GoUint64);
 }


### PR DESCRIPTION
Bumps to the latest version of cosmwasm, unlocking blockers for libraries testing with the latest cosmwasm version.

TODO:
- Some dependencies have been modified to rely on forks of crates also updated to Cosmwasm@v3. Specifically:
    - cw-plus: [Issue #921](https://github.com/CosmWasm/cw-plus/issues/921)
    - neturon-std: [PR #15](https://github.com/neutron-org/neutron-std/pull/15)
    - cosmrs: [PR #525](https://github.com/cosmos/cosmos-rust/pull/525)
- Ensure semantic versioning is accurate

## NOTES
- **Neutron x CW@V3 Support**: Neutron does not yet support the latest version of [Cosmwasm's VM](https://github.com/CosmWasm/wasmvm/releases/tag/v3.0.2). These changes are irrelevant until then, (EXCEPT for external workspaces that are compatible with the latest CW version, & import this crate as a dependency)